### PR TITLE
Update scope.js

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -75,7 +75,7 @@ function $RootScopeProvider() {
 			var watcher = {
 				watchFn: watchFn,
 				listenerFn: listenerFn || _.noop,
-				last: initWatchVal,
+				last: initWatchVal(),
 				valueEq: !!valueEq
 			};
 


### PR DESCRIPTION
It would cause the specs fail in $watchGroup, lastValue should be a value but not a function.