### PR TITLE
$$areEqual method does not need special case for NaN checks

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -315,9 +315,7 @@ function $RootScopeProvider() {
 			if (valueEq) {
 				return _.isEqual(newValue, oldValue);
 			} else {
-				return newValue === oldValue ||
-					(typeof newValue === 'number' && typeof oldValue === 'number' &&
-					isNaN(newValue) && isNaN(oldValue));
+				return newValue === oldValue;
 			}
 		};
 


### PR DESCRIPTION
See issue #333.